### PR TITLE
Support for PHP 8 and PHPUnit 9

### DIFF
--- a/Code/Generator.php
+++ b/Code/Generator.php
@@ -8,6 +8,7 @@ use Magento\Framework\{
     Code\Generator\Io,
     Filesystem\Driver\File as Reader
 };
+use Olmer\UnitTestsGenerator\Code\Generator\ClassNameParser;
 
 class Generator
 {
@@ -23,6 +24,10 @@ class Generator
      * @var Reader
      */
     private $reader;
+    /**
+     * @var ClassNameParser
+     */
+    private $classNameParser;
 
     /**
      * Generator constructor.
@@ -34,11 +39,13 @@ class Generator
     public function __construct(
         Generator\UnitTestFactory $testGenerator,
         Io $ioObject,
-        Reader $reader
+        Reader $reader,
+        ClassNameParser $classNameParser
     ) {
         $this->testGeneratorFactory = $testGenerator;
         $this->ioObject = $ioObject;
         $this->reader = $reader;
+        $this->classNameParser = $classNameParser;
     }
 
     /**
@@ -81,41 +88,6 @@ class Generator
         }
 
         $fileContents = $this->reader->fileGetContents($path);
-        return $this->parseClassName($fileContents);
-    }
-
-    /**
-     * @param string $content
-     *
-     * @return string
-     */
-    private function parseClassName(string $content): string
-    {
-        $class = $namespace = '';
-        $i = 0;
-        $tokens = \token_get_all($content);
-        $tokensCount = \count($tokens);
-        for (; $i < $tokensCount; $i++) {
-            if ($tokens[$i][0] === T_NAMESPACE) {
-                for ($j = $i + 1; $j < $tokensCount; $j++) {
-                    if ($tokens[$j][0] === T_STRING) {
-                        $namespace .= '\\' . $tokens[$j][1];
-                    } else {
-                        if ($tokens[$j] === '{' || $tokens[$j] === ';') {
-                            break;
-                        }
-                    }
-                }
-            }
-            if ($tokens[$i][0] === T_CLASS) {
-                for ($j = $i + 1; $j < $tokensCount; $j++) {
-                    if ($tokens[$j] === '{') {
-                        $class = '\\' . $tokens[$i + 2][1];
-                        break 2;
-                    }
-                }
-            }
-        }
-        return $namespace . $class;
+        return $this->classNameParser->parseClassName($fileContents);
     }
 }

--- a/Code/Generator/ClassNameParser.php
+++ b/Code/Generator/ClassNameParser.php
@@ -20,7 +20,8 @@ class ClassNameParser
         for (; $i < $tokensCount; $i++) {
             if ($tokens[$i][0] === T_NAMESPACE) {
                 for ($j = $i + 1; $j < $tokensCount; $j++) {
-                    if ($tokens[$j][0] === T_STRING) {
+                    // T_NAME_QUALIFIED for PHP > 8.0, T_STRING as fallback
+                    if ($tokens[$j][0] === T_NAME_QUALIFIED || $tokens[$j][0] === T_STRING) {
                         $namespace .= '\\' . $tokens[$j][1];
                     } else {
                         if ($tokens[$j] === '{' || $tokens[$j] === ';') {

--- a/Code/Generator/ClassNameParser.php
+++ b/Code/Generator/ClassNameParser.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Olmer\UnitTestsGenerator\Code\Generator;
+
+class ClassNameParser
+{
+    /**
+     * @param string $content
+     *
+     * @return string
+     */
+    public function parseClassName(string $content): string
+    {
+        $class = $namespace = '';
+        $i = 0;
+        $tokens = \token_get_all($content);
+        $tokensCount = \count($tokens);
+        for (; $i < $tokensCount; $i++) {
+            if ($tokens[$i][0] === T_NAMESPACE) {
+                for ($j = $i + 1; $j < $tokensCount; $j++) {
+                    if ($tokens[$j][0] === T_STRING) {
+                        $namespace .= '\\' . $tokens[$j][1];
+                    } else {
+                        if ($tokens[$j] === '{' || $tokens[$j] === ';') {
+                            break;
+                        }
+                    }
+                }
+            }
+            if ($tokens[$i][0] === T_CLASS) {
+                for ($j = $i + 1; $j < $tokensCount; $j++) {
+                    if ($tokens[$j] === '{') {
+                        $class = '\\' . $tokens[$i + 2][1];
+                        break 2;
+                    }
+                }
+            }
+        }
+        return $namespace . $class;
+    }
+}

--- a/Code/Generator/ClassNameParser.php
+++ b/Code/Generator/ClassNameParser.php
@@ -21,7 +21,8 @@ class ClassNameParser
             if ($tokens[$i][0] === T_NAMESPACE) {
                 for ($j = $i + 1; $j < $tokensCount; $j++) {
                     // T_NAME_QUALIFIED for PHP > 8.0, T_STRING as fallback
-                    if ($tokens[$j][0] === T_NAME_QUALIFIED || $tokens[$j][0] === T_STRING) {
+                    $qualifiedNameToken = defined('T_NAME_QUALIFIED') ? T_NAME_QUALIFIED : T_STRING;
+                    if ($tokens[$j][0] === $qualifiedNameToken) {
                         $namespace .= '\\' . $tokens[$j][1];
                     } else {
                         if ($tokens[$j] === '{' || $tokens[$j] === ';') {

--- a/Code/Generator/UnitTest.php
+++ b/Code/Generator/UnitTest.php
@@ -190,9 +190,8 @@ class UnitTest extends \Magento\Framework\Code\Generator\EntityAbstract
     {
         if ($this->constructorArguments === null) {
             try {
-                $this->constructorArguments = $this->constructorArgumentsResolver->resolve(
-                    $this->getSourceReflectionClass()
-                );
+                $constructor = $this->getSourceReflectionClass()->getMethod('__construct');
+                $this->constructorArguments = $this->constructorArgumentsResolver->resolve($constructor);
             } catch (\ReflectionException $e) {
                 $this->constructorArguments = [];
             }

--- a/Code/Generator/UnitTest.php
+++ b/Code/Generator/UnitTest.php
@@ -73,7 +73,7 @@ class UnitTest extends \Magento\Framework\Code\Generator\EntityAbstract
                 'visibility' => 'private',
                 'docblock' => [
                     'shortDescription' => "Mock {$e['name']}",
-                    'tags' => [['name' => 'var', 'description' => '\\' . "{$e['class']}|PHPUnit_Framework_MockObject_MockObject"]],
+                    'tags' => [['name' => 'var', 'description' => '\\' . "{$e['class']}|" . \PHPUnit\Framework\MockObject\MockObject::class]],
                 ],
             ];
         }, $this->getConstructorArgumentsWithFactoryInstances());
@@ -319,7 +319,7 @@ BODY;
             \PHPUnit\Framework\TestCase::class
         );
         $this->_classGenerator->addUse(
-            \PHPUnit_Framework_MockObject_MockObject::class
+            \PHPUnit\Framework\MockObject\MockObject::class
         );
     }
 

--- a/Code/Generator/UnitTest/ConstructorArgumentsResolver.php
+++ b/Code/Generator/UnitTest/ConstructorArgumentsResolver.php
@@ -17,12 +17,12 @@ class ConstructorArgumentsResolver
 
         try {
             foreach ($constructor->getParameters() as $parameter) {
-                if (!$parameter->getClass()) {
+                if (!$parameter->getType()) {
                     continue;
                 }
                 $constructorArguments[] = [
                     'name' => $parameter->getName(),
-                    'class' => $parameter->getClass()->getName()
+                    'class' => $parameter->getType()->getName()
                 ];
             }
         } catch (\ReflectionException $e) {

--- a/Code/Generator/UnitTest/ConstructorArgumentsResolver.php
+++ b/Code/Generator/UnitTest/ConstructorArgumentsResolver.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Olmer\UnitTestsGenerator\Code\Generator\UnitTest;
+
+class ConstructorArgumentsResolver
+{
+    /**
+     * @param \ReflectionClass $reflectionClass
+     *
+     * @return array
+     */
+    public function resolve(\ReflectionClass $reflectionClass): array
+    {
+        $constructorArguments = [];
+
+        try {
+            $method = $reflectionClass->getMethod('__construct');
+            foreach ($method->getParameters() as $parameter) {
+                if (!$parameter->getClass()) {
+                    continue;
+                }
+                $constructorArguments[] = [
+                    'name' => $parameter->getName(),
+                    'class' => $parameter->getClass()->getName()
+                ];
+            }
+        } catch (\ReflectionException $e) {
+            return $constructorArguments;
+        }
+
+        return $constructorArguments;
+    }
+}

--- a/Code/Generator/UnitTest/ConstructorArgumentsResolver.php
+++ b/Code/Generator/UnitTest/ConstructorArgumentsResolver.php
@@ -7,17 +7,16 @@ namespace Olmer\UnitTestsGenerator\Code\Generator\UnitTest;
 class ConstructorArgumentsResolver
 {
     /**
-     * @param \ReflectionClass $reflectionClass
+     * @param \ReflectionMethod $constructor
      *
      * @return array
      */
-    public function resolve(\ReflectionClass $reflectionClass): array
+    public function resolve(\ReflectionMethod $constructor): array
     {
         $constructorArguments = [];
 
         try {
-            $method = $reflectionClass->getMethod('__construct');
-            foreach ($method->getParameters() as $parameter) {
+            foreach ($constructor->getParameters() as $parameter) {
                 if (!$parameter->getClass()) {
                     continue;
                 }

--- a/Code/Generator/UnitTest/SetupMethodBuilder.php
+++ b/Code/Generator/UnitTest/SetupMethodBuilder.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Olmer\UnitTestsGenerator\Code\Generator\UnitTest;
+
+class SetupMethodBuilder
+{
+    /**
+     * @param array $setupMethodParamsDefinition
+     * @param string $testObjectCreationCode
+     *
+     * @return array
+     */
+    public function build(array $setupMethodParamsDefinition, string $testObjectCreationCode): array
+    {
+        return [
+            'name' => 'setUp',
+            'parameters' => [],
+            'body' => "\$this->objectManager = new ObjectManager(\$this);\n"
+                . \implode("\n", $setupMethodParamsDefinition) . "\n"
+                . $testObjectCreationCode,
+            'docblock' => [
+                'shortDescription' => 'Main set up method',
+            ],
+            'returnType' => 'void'
+        ];
+    }
+}

--- a/Code/Generator/UnitTest/TestObjectCreationBuilder.php
+++ b/Code/Generator/UnitTest/TestObjectCreationBuilder.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Olmer\UnitTestsGenerator\Code\Generator\UnitTest;
+
+class TestObjectCreationBuilder
+{
+    /**
+     * @param string $sourceClassName
+     * @param array $objectCreationParams
+     *
+     * @return string
+     */
+    public function build(
+        string $sourceClassName,
+        array $objectCreationParams
+    ): string {
+        return "\$this->testObject = \$this->objectManager->getObject(\n"
+            . $sourceClassName . "::class,\n"
+            . "    [\n"
+            . \implode("\n", $objectCreationParams)
+            . "\n    ]\n"
+            . ");";
+    }
+}

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ namespace Vendor\Reorder\Test\Unit\Helper;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @covers \Vendor\Reorder\Helper\Reorder
@@ -72,49 +72,49 @@ class ReorderTest extends TestCase
     /**
      * Mock context
      *
-     * @var \Magento\Framework\App\Helper\Context|PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\App\Helper\Context|PHPUnit\Framework\MockObject\MockObject
      */
     private $context;
 
     /**
      * Mock orderRepository
      *
-     * @var \Magento\Sales\Api\OrderRepositoryInterface|PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Sales\Api\OrderRepositoryInterface|PHPUnit\Framework\MockObject\MockObject
      */
     private $orderRepository;
 
     /**
      * Mock criteria
      *
-     * @var \Magento\Framework\Api\SearchCriteriaFactory|PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Api\SearchCriteriaFactory|PHPUnit\Framework\MockObject\MockObject
      */
     private $criteria;
 
     /**
      * Mock filterGroup
      *
-     * @var \Magento\Framework\Api\Search\FilterGroupFactory|PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Api\Search\FilterGroupFactory|PHPUnit\Framework\MockObject\MockObject
      */
     private $filterGroup;
 
     /**
      * Mock filter
      *
-     * @var \Magento\Framework\Api\FilterFactory|PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Api\FilterFactory|PHPUnit\Framework\MockObject\MockObject
      */
     private $filter;
 
     /**
      * Mock orderFactory
      *
-     * @var \Magento\Sales\Model\OrderFactory|PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Sales\Model\OrderFactory|PHPUnit\Framework\MockObject\MockObject
      */
     private $orderFactory;
 
     /**
      * Mock sortOrderFactory
      *
-     * @var \Magento\Framework\Api\SortOrderFactory|PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Api\SortOrderFactory|PHPUnit\Framework\MockObject\MockObject
      */
     private $sortOrderFactory;
 
@@ -135,7 +135,7 @@ class ReorderTest extends TestCase
     /**
      * Main set up method
      */
-    public function setUp()
+    public function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
         $this->context = $this->createMock(\Magento\Framework\App\Helper\Context::class);

--- a/Test/Unit/Code/Generator/ClassNameParserTest.php
+++ b/Test/Unit/Code/Generator/ClassNameParserTest.php
@@ -1,0 +1,65 @@
+<?php
+namespace Olmer\UnitTestsGenerator\Test\Unit\Code\Generator;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * @covers \Olmer\UnitTestsGenerator\Code\Generator\ClassNameParser
+ */
+class ClassNameParserTest extends TestCase
+{
+    /**
+     * Object Manager instance
+     *
+     * @var \Magento\Framework\ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * Object to test
+     *
+     * @var \Olmer\UnitTestsGenerator\Code\Generator\ClassNameParser
+     */
+    private $testObject;
+
+    /**
+     * Main set up method
+     */
+    public function setUp(): void
+    {
+        $this->objectManager = new ObjectManager($this);
+
+        $this->testObject = $this->objectManager->getObject(
+        \Olmer\UnitTestsGenerator\Code\Generator\ClassNameParser::class
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderForTestParseClassName()
+    {
+        return [
+            'basic Magento class' => [
+                'content' => '<?php' . PHP_EOL . 'declare(strict_types=1);' . PHP_EOL . 'namespace Olmer\UnitTestsGenerator\Code\Generator;class ClassNameParser{}',
+                'expectedResult' => '\Olmer\UnitTestsGenerator\Code\Generator\ClassNameParser'
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForTestParseClassName
+     *
+     * @param string $content
+     * @param string $expected
+     *
+     * @return void
+     */
+    public function testParseClassName(string $content, string $expected)
+    {
+        $result = $this->testObject->parseClassName($content);
+        $this->assertEquals($expected, $result);
+    }
+}

--- a/Test/Unit/Code/Generator/ClassNameParserTest.php
+++ b/Test/Unit/Code/Generator/ClassNameParserTest.php
@@ -3,7 +3,6 @@ namespace Olmer\UnitTestsGenerator\Test\Unit\Code\Generator;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @covers \Olmer\UnitTestsGenerator\Code\Generator\ClassNameParser

--- a/Test/Unit/Code/Generator/UnitTest/ConstructorArgumentsResolverTest.php
+++ b/Test/Unit/Code/Generator/UnitTest/ConstructorArgumentsResolverTest.php
@@ -72,10 +72,10 @@ class ConstructorArgumentsResolverTest extends TestCase
             $parameter = $this->createMock(\ReflectionParameter::class);
             $class = null;
             if ($className) {
-                $class = $this->createMock(\ReflectionClass::class);
+                $class = $this->createMock(\ReflectionNamedType::class);
                 $class->method('getName')->willReturn($className);
             }
-            $parameter->method('getClass')->willReturn($class);
+            $parameter->method('getType')->willReturn($class);
             $parameter->method('getName')->willReturn($name);
             $parameters[] = $parameter;
         }

--- a/Test/Unit/Code/Generator/UnitTest/ConstructorArgumentsResolverTest.php
+++ b/Test/Unit/Code/Generator/UnitTest/ConstructorArgumentsResolverTest.php
@@ -1,0 +1,86 @@
+<?php
+namespace Olmer\UnitTestsGenerator\Test\Unit\Code\Generator\UnitTest;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * @covers \Olmer\UnitTestsGenerator\Code\Generator\UnitTest\ConstructorArgumentsResolver
+ */
+class ConstructorArgumentsResolverTest extends TestCase
+{
+    /**
+     * Object Manager instance
+     *
+     * @var \Magento\Framework\ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * Object to test
+     *
+     * @var \Olmer\UnitTestsGenerator\Code\Generator\UnitTest\ConstructorArgumentsResolver
+     */
+    private $testObject;
+
+    /**
+     * @var \ReflectionMethod
+     */
+    private $constructor;
+
+    /**
+     * Main set up method
+     */
+    public function setUp(): void
+    {
+        $this->objectManager = new ObjectManager($this);
+
+        $this->testObject = $this->objectManager->getObject(
+        \Olmer\UnitTestsGenerator\Code\Generator\UnitTest\ConstructorArgumentsResolver::class,
+        );
+        $this->constructor = $this->createMock(\ReflectionMethod::class);
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderForTestResolve()
+    {
+        return [
+            'Testcase 1' => [
+                'constructorParametersData' => [
+                    'name1' => 'class1',
+                    'name2' => 'class2',
+                    'name3' => null
+                ],
+                'result' => [
+                    ['name' => 'name1', 'class' => 'class1'],
+                    ['name' => 'name2', 'class' => 'class2']
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForTestResolve
+     */
+    public function testResolve(array $constructorParametersData, array $expectedResult)
+    {
+        $parameters = [];
+        foreach ($constructorParametersData as $name => $className) {
+            $parameter = $this->createMock(\ReflectionParameter::class);
+            $class = null;
+            if ($className) {
+                $class = $this->createMock(\ReflectionClass::class);
+                $class->method('getName')->willReturn($className);
+            }
+            $parameter->method('getClass')->willReturn($class);
+            $parameter->method('getName')->willReturn($name);
+            $parameters[] = $parameter;
+        }
+        $this->constructor->method('getParameters')->willReturn($parameters);
+        $result = $this->testObject->resolve($this->constructor);
+        $this->assertEquals($expectedResult, $result);
+    }
+}

--- a/Test/Unit/Code/Generator/UnitTest/SetupMethodBuilderTest.php
+++ b/Test/Unit/Code/Generator/UnitTest/SetupMethodBuilderTest.php
@@ -1,0 +1,92 @@
+<?php
+namespace Olmer\UnitTestsGenerator\Test\Unit\Code\Generator\UnitTest;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Olmer\UnitTestsGenerator\Code\Generator\UnitTest\SetupMethodBuilder
+ */
+class SetupMethodBuilderTest extends TestCase
+{
+    /**
+     * Object Manager instance
+     *
+     * @var \Magento\Framework\ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * Object to test
+     *
+     * @var \Olmer\UnitTestsGenerator\Code\Generator\UnitTest\SetupMethodBuilder
+     */
+    private $testObject;
+
+    /**
+     * Main set up method
+     */
+    public function setUp(): void
+    {
+        $this->objectManager = new ObjectManager($this);
+
+        $this->testObject = $this->objectManager->getObject(
+            \Olmer\UnitTestsGenerator\Code\Generator\UnitTest\SetupMethodBuilder::class
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderForTestBuild()
+    {
+        return [
+            'No params, simple test object' => [
+                'setupMethodParamsDefinition' => [],
+                'testObjectCreationCode' => "\$this->testObject = \$this->objectManager->getObject(\nTestObject::class,\n"
+                    . "    [\n    ]\n);",
+                'expectedResult' => [
+                    'name' => 'setUp',
+                    'body' => "\$this->objectManager = new ObjectManager(\$this);\n\n"
+                        . "\$this->testObject = \$this->objectManager->getObject(\nTestObject::class,\n"
+                        . "    [\n    ]\n);",
+                    'parameters' => [],
+                    'docblock' => [
+                        'shortDescription' => 'Main set up method',
+                    ],
+                    'returnType' => 'void'
+                ]
+            ],
+            'Some params, simple test object' => [
+                'setupMethodParamsDefinition' => [
+                    "\$this->fooFactory = \$this->createMock(FooFactory::class);",
+                    "\$this->fooFactory->method('create')->willReturn(\$this->createMock(Foo::class);"
+                ],
+                'testObjectCreationCode' => "\$this->testObject = \$this->objectManager->getObject(\nTestObject::class,\n"
+                    . "    [\n    ]\n);",
+                'expectedResult' => [
+                    'name' => 'setUp',
+                    'body' => "\$this->objectManager = new ObjectManager(\$this);\n"
+                        . "\$this->fooFactory = \$this->createMock(FooFactory::class);\n"
+                        . "\$this->fooFactory->method('create')->willReturn(\$this->createMock(Foo::class);\n"
+                        . "\$this->testObject = \$this->objectManager->getObject(\nTestObject::class,\n"
+                        . "    [\n    ]\n);",
+                    'parameters' => [],
+                    'docblock' => [
+                        'shortDescription' => 'Main set up method',
+                    ],
+                    'returnType' => 'void'
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForTestBuild
+     */
+    public function testBuild(array $setupMethodParamsDefinition, string $testObjectCreationCode, array $expectedResult)
+    {
+        $result = $this->testObject->build($setupMethodParamsDefinition, $testObjectCreationCode);
+        $this->assertEquals($expectedResult, $result);
+    }
+}

--- a/Test/Unit/Code/Generator/UnitTest/TestObjectCreationBuilderTest.php
+++ b/Test/Unit/Code/Generator/UnitTest/TestObjectCreationBuilderTest.php
@@ -1,0 +1,71 @@
+<?php
+namespace Olmer\UnitTestsGenerator\Test\Unit\Code\Generator\UnitTest;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Olmer\UnitTestsGenerator\Code\Generator\UnitTest\TestObjectCreationBuilder
+ */
+class TestObjectCreationBuilderTest extends TestCase
+{
+    /**
+     * Object Manager instance
+     *
+     * @var \Magento\Framework\ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * Object to test
+     *
+     * @var \Olmer\UnitTestsGenerator\Code\Generator\UnitTest\TestObjectCreationBuilder
+     */
+    private $testObject;
+
+    /**
+     * Main set up method
+     */
+    public function setUp() : void
+    {
+        $this->objectManager = new ObjectManager($this);
+
+        $this->testObject = $this->objectManager->getObject(
+            \Olmer\UnitTestsGenerator\Code\Generator\UnitTest\TestObjectCreationBuilder::class,
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderForTestBuild()
+    {
+        return [
+            'No params' => [
+                'objectCreationParams' => [],
+                'expectedResult' => "\$this->testObject = \$this->objectManager->getObject(\nFoo::class,\n"
+                        . "    [\n\n    ]\n);"
+            ],
+            'Some params' => [
+                'objectCreationParams' => [
+                    "        'param1' => \$this->param1,",
+                    "        'param2' => \$this->param2,"
+                ],
+                'expectedResult' => "\$this->testObject = \$this->objectManager->getObject(\nFoo::class,\n"
+                    . "    [\n"
+                    . "        'param1' => \$this->param1,\n"
+                    . "        'param2' => \$this->param2,\n"
+                    . "    ]\n);"
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForTestBuild
+     */
+    public function testBuild(array $objectCreationParams, string $expectedResult)
+    {
+        $result = $this->testObject->build('Foo', $objectCreationParams);
+        $this->assertEquals($expectedResult, $result);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "magento/framework": "*",
-        "php": "^7.0"
+        "php": "^7.0 || ^8.0"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,9 @@
         "magento/framework": "*",
         "php": "^7.0 || ^8.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^9"
+    },
     "autoload": {
         "files": [
             "registration.php"


### PR DESCRIPTION
Basically, so that it now works with M2.4.4. I didn't refactor ObjectManager helper usage (yet) which is apparently deprecated.

Biggest change was that T_STRING in figuring out namespace path parts no longer worked - PHP 8 introduced T_NAME_QUALIFIED for this. I tried to preserve PHP 7 compatibility.

I also added void return type to setUp, and replaced underscores with backslashes for MockObject.

The rest is refactoring and unit test coverage - creating the latter worked as an acceptance test for the tool.

Thanks for creating the tool in the first place!