### PR TITLE
Php 8.2 compatibility 

### DIFF
--- a/Console/Command/Generate.php
+++ b/Console/Command/Generate.php
@@ -35,6 +35,10 @@ class Generate extends Command
      * @var ObjectManagerFactory
      */
     private $objectManagerFactory;
+    /**
+     * @var mixed
+     */
+    private $model;
 
     /**
      * AbstractCommand constructor.


### PR DESCRIPTION
Adds private variable model to Generate command so that the module is compatible with php 8.2 version.

Without this change, the command bin/magento dev:tests:generate-unit  <path-to-file> throws error
`Deprecated Functionality: Creation of dynamic property Olmer\UnitTestsGenerator\Console\Command\Generate\Interceptor::$model is deprecated in /var/www/html/vendor/olmer/magento-unit-tests-generator/Console/Command/Generate.php on line 98`
when using php 8.2